### PR TITLE
Add dark themed Schwab portfolio login page

### DIFF
--- a/Proof of Concept/portfolioLogin.html
+++ b/Proof of Concept/portfolioLogin.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Schwab Portfolio Login</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            color-scheme: dark;
+            --background: #0c0f17;
+            --surface: #141b29;
+            --surface-muted: #1e2738;
+            --accent: #4c8bf5;
+            --accent-strong: #6da2ff;
+            --text-primary: #f4f7ff;
+            --text-secondary: #a9b5d1;
+            --border: rgba(255, 255, 255, 0.08);
+            --danger: #ff6b6b;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: radial-gradient(circle at top, rgba(76, 139, 245, 0.22), transparent 55%),
+                        radial-gradient(circle at bottom, rgba(255, 255, 255, 0.03), transparent 40%),
+                        var(--background);
+            color: var(--text-primary);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+        }
+
+        main {
+            width: min(480px, 100%);
+        }
+
+        .card {
+            background: linear-gradient(145deg, rgba(30, 39, 56, 0.9), rgba(12, 15, 23, 0.95));
+            border: 1px solid var(--border);
+            border-radius: 18px;
+            padding: 36px;
+            backdrop-filter: blur(20px);
+            box-shadow:
+                0 20px 45px rgba(12, 15, 23, 0.75),
+                0 0 0 1px rgba(76, 139, 245, 0.04);
+        }
+
+        header {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            margin-bottom: 32px;
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 1.9rem;
+            letter-spacing: 0.04em;
+        }
+
+        header p {
+            margin: 0;
+            color: var(--text-secondary);
+            line-height: 1.6;
+        }
+
+        form {
+            display: grid;
+            gap: 20px;
+        }
+
+        label {
+            display: block;
+            font-size: 0.95rem;
+            font-weight: 500;
+            margin-bottom: 8px;
+        }
+
+        .input-group {
+            display: flex;
+            flex-direction: column;
+        }
+
+        input[type="text"],
+        input[type="password"] {
+            width: 100%;
+            padding: 14px 16px;
+            border-radius: 12px;
+            border: 1px solid var(--border);
+            background: var(--surface);
+            color: var(--text-primary);
+            font-size: 1rem;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+        }
+
+        input[type="text"]:focus,
+        input[type="password"]:focus {
+            outline: none;
+            border-color: rgba(76, 139, 245, 0.65);
+            box-shadow: 0 0 0 3px rgba(76, 139, 245, 0.25);
+            transform: translateY(-1px);
+        }
+
+        .options {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            flex-wrap: wrap;
+            font-size: 0.92rem;
+        }
+
+        .checkbox {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            cursor: pointer;
+            color: var(--text-secondary);
+        }
+
+        .checkbox input {
+            width: 18px;
+            height: 18px;
+            border-radius: 4px;
+            border: 1px solid var(--border);
+            appearance: none;
+            background: var(--surface);
+            display: grid;
+            place-items: center;
+            transition: border-color 0.2s ease, background 0.2s ease;
+        }
+
+        .checkbox input::after {
+            content: "";
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+            transform: scale(0);
+            transition: transform 0.2s ease;
+            background: var(--accent);
+        }
+
+        .checkbox input:checked {
+            border-color: var(--accent);
+            background: rgba(76, 139, 245, 0.2);
+        }
+
+        .checkbox input:checked::after {
+            transform: scale(1);
+        }
+
+        .options a {
+            color: var(--accent-strong);
+            text-decoration: none;
+            font-weight: 500;
+            transition: color 0.2s ease;
+        }
+
+        .options a:hover,
+        .options a:focus {
+            color: #8bb6ff;
+        }
+
+        button {
+            border: none;
+            border-radius: 12px;
+            padding: 14px 18px;
+            font-size: 1rem;
+            font-weight: 600;
+            background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+            color: white;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        button:hover,
+        button:focus {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 25px rgba(76, 139, 245, 0.35);
+        }
+
+        .secondary-actions {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 24px;
+            gap: 12px;
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+        }
+
+        .secondary-actions a {
+            color: var(--accent-strong);
+            text-decoration: none;
+        }
+
+        .divider {
+            height: 1px;
+            background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+            margin: 12px 0;
+        }
+
+        footer {
+            margin-top: 40px;
+            text-align: center;
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            line-height: 1.6;
+        }
+
+        @media (max-width: 520px) {
+            .card {
+                padding: 28px 24px;
+            }
+
+            header h1 {
+                font-size: 1.6rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <section class="card" aria-labelledby="login-title">
+            <header>
+                <p style="font-size: 0.95rem; color: var(--accent-strong); letter-spacing: 0.18em; text-transform: uppercase;">
+                    Schwab Portfolio Tracker
+                </p>
+                <h1 id="login-title">Welcome back</h1>
+                <p>Access your personalized dashboard to monitor positions, performance, and daily insights from your Schwab portfolio.</p>
+            </header>
+
+            <form>
+                <div class="input-group">
+                    <label for="username">Username</label>
+                    <input type="text" id="username" name="username" autocomplete="username" placeholder="Enter Schwab ID" required />
+                </div>
+
+                <div class="input-group">
+                    <label for="password">Password</label>
+                    <input type="password" id="password" name="password" autocomplete="current-password" placeholder="Enter password" required />
+                </div>
+
+                <div class="options">
+                    <label class="checkbox">
+                        <input type="checkbox" id="remember" name="remember" />
+                        <span>Remember device</span>
+                    </label>
+                    <a href="#">Forgot password?</a>
+                </div>
+
+                <button type="submit">Log In</button>
+
+                <div class="secondary-actions">
+                    <span>Need an account?</span>
+                    <a href="#">Start tracking your portfolio</a>
+                </div>
+            </form>
+
+            <div class="divider" role="presentation"></div>
+
+            <footer>
+                <p>For demo purposes only. Connect your Schwab account in the live tracker to sync holdings automatically.</p>
+            </footer>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone Schwab portfolio login page with a dark glassmorphism aesthetic
- style the form with accessible focus states, gradients, and responsive layout for mobile

## Testing
- no automated tests were run (frontend static page)


------
https://chatgpt.com/codex/tasks/task_e_68dbef1a22888325b87cd5e983380565