### PR TITLE
Add Schwab portfolio dashboard page

### DIFF
--- a/Proof of Concept/portfolioDashboard.html
+++ b/Proof of Concept/portfolioDashboard.html
@@ -1,0 +1,487 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Schwab Portfolio Tracker</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js" defer></script>
+    <style>
+        :root {
+            color-scheme: dark;
+            --background: #0c0f17;
+            --surface: #141b29;
+            --surface-muted: #1c2435;
+            --surface-glass: rgba(22, 30, 44, 0.85);
+            --accent: #4c8bf5;
+            --accent-strong: #6da2ff;
+            --text-primary: #f4f7ff;
+            --text-secondary: #a9b5d1;
+            --border: rgba(255, 255, 255, 0.08);
+            --positive: #4fd1a7;
+            --negative: #ff6b6b;
+        }
+
+        *, *::before, *::after {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: radial-gradient(circle at top, rgba(76, 139, 245, 0.22), transparent 55%),
+                        radial-gradient(circle at bottom, rgba(79, 209, 167, 0.08), transparent 40%),
+                        var(--background);
+            color: var(--text-primary);
+            display: flex;
+            flex-direction: column;
+        }
+
+        header {
+            padding: 32px clamp(16px, 5vw, 64px) 16px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: clamp(1.8rem, 2.6vw, 2.6rem);
+            letter-spacing: 0.03em;
+        }
+
+        header p {
+            margin: 4px 0 0;
+            color: var(--text-secondary);
+            font-size: 0.98rem;
+            max-width: 480px;
+            line-height: 1.6;
+        }
+
+        main {
+            flex: 1;
+            padding: 0 clamp(16px, 5vw, 64px) 64px;
+            display: flex;
+            flex-direction: column;
+            gap: 32px;
+        }
+
+        .summary-grid {
+            display: grid;
+            gap: 20px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        .metric-card {
+            background: linear-gradient(150deg, rgba(30, 39, 56, 0.92), rgba(12, 15, 23, 0.95));
+            border: 1px solid var(--border);
+            border-radius: 18px;
+            padding: 22px 24px;
+            backdrop-filter: blur(18px);
+            box-shadow:
+                0 16px 38px rgba(9, 12, 20, 0.6),
+                0 0 0 1px rgba(76, 139, 245, 0.05);
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .metric-label {
+            font-size: 0.9rem;
+            color: var(--text-secondary);
+            letter-spacing: 0.02em;
+        }
+
+        .metric-value {
+            font-size: 1.7rem;
+            font-weight: 600;
+            letter-spacing: 0.03em;
+        }
+
+        .metric-delta {
+            font-size: 0.95rem;
+            font-weight: 500;
+        }
+
+        .metric-delta.positive {
+            color: var(--positive);
+        }
+
+        .metric-delta.negative {
+            color: var(--negative);
+        }
+
+        .chart-card {
+            background: var(--surface-glass);
+            border: 1px solid var(--border);
+            border-radius: 22px;
+            padding: 28px;
+            backdrop-filter: blur(20px);
+            box-shadow:
+                0 18px 45px rgba(8, 12, 22, 0.7),
+                0 0 0 1px rgba(76, 139, 245, 0.04);
+            display: grid;
+            gap: 24px;
+        }
+
+        .chart-header {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: 16px;
+        }
+
+        .chart-header h2 {
+            margin: 0;
+            font-size: 1.3rem;
+            letter-spacing: 0.03em;
+        }
+
+        .text-muted {
+            margin: 6px 0 0;
+            color: rgba(255, 255, 255, 0.6);
+            font-size: 0.92rem;
+            letter-spacing: 0.015em;
+        }
+
+        .filters {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            align-items: center;
+        }
+
+        .filters button {
+            background: rgba(76, 139, 245, 0.16);
+            border: 1px solid transparent;
+            color: var(--accent-strong);
+            padding: 10px 18px;
+            border-radius: 999px;
+            font-weight: 600;
+            font-size: 0.92rem;
+            letter-spacing: 0.02em;
+            cursor: pointer;
+            transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+        }
+
+        .filters button.active {
+            background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+            border-color: rgba(255, 255, 255, 0.15);
+            color: white;
+            box-shadow: 0 10px 25px rgba(76, 139, 245, 0.35);
+        }
+
+        .filters button:hover,
+        .filters button:focus {
+            transform: translateY(-1px);
+            outline: none;
+        }
+
+        .custom-range {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            border-radius: 999px;
+            padding: 8px 14px;
+            border: 1px solid var(--border);
+            background: rgba(19, 25, 38, 0.75);
+        }
+
+        .custom-range label {
+            font-size: 0.85rem;
+            color: var(--text-secondary);
+        }
+
+        .custom-range input {
+            background: transparent;
+            border: none;
+            color: var(--text-primary);
+            font-size: 0.9rem;
+        }
+
+        .custom-range input::-webkit-calendar-picker-indicator {
+            filter: invert(1);
+        }
+
+        .custom-range button {
+            padding: 8px 14px;
+            border-radius: 8px;
+            border: 1px solid transparent;
+            background: rgba(76, 139, 245, 0.28);
+            color: var(--text-primary);
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+
+        .custom-range button:hover,
+        .custom-range button:focus {
+            background: rgba(76, 139, 245, 0.45);
+            outline: none;
+        }
+
+        canvas {
+            width: 100% !important;
+            height: 360px !important;
+        }
+
+        @media (max-width: 768px) {
+            .chart-card {
+                padding: 22px;
+            }
+
+            canvas {
+                height: 300px !important;
+            }
+
+            .custom-range {
+                width: 100%;
+                flex-wrap: wrap;
+                justify-content: center;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div>
+            <h1>Portfolio Overview</h1>
+            <p>Track your Schwab portfolio's performance, total balances, and investment gains in real time with a clear, focused dashboard.</p>
+        </div>
+        <div class="timestamp" aria-live="polite"></div>
+    </header>
+
+    <main>
+        <section class="summary-grid" aria-label="Portfolio summary">
+            <article class="metric-card">
+                <span class="metric-label">Total Account Value</span>
+                <span class="metric-value" id="totalAccountValue">$148,520.32</span>
+                <span class="metric-delta positive" id="totalAccountValueDelta">▲ $1,842.12 (1.26%)</span>
+            </article>
+            <article class="metric-card">
+                <span class="metric-label">Total Cash &amp; Cash Invest</span>
+                <span class="metric-value" id="totalCash">$28,430.00</span>
+                <span class="metric-delta" id="totalCashDelta">$0.00</span>
+            </article>
+            <article class="metric-card">
+                <span class="metric-label">Total Market Value</span>
+                <span class="metric-value" id="totalMarketValue">$120,090.32</span>
+                <span class="metric-delta positive" id="totalMarketValueDelta">▲ $1,210.54 (1.02%)</span>
+            </article>
+            <article class="metric-card">
+                <span class="metric-label">Total Day Change</span>
+                <span class="metric-value positive" id="totalDayChange">+$546.20</span>
+                <span class="metric-delta positive" id="totalDayChangePercent">+0.37%</span>
+            </article>
+            <article class="metric-card">
+                <span class="metric-label">Total Cost Basis</span>
+                <span class="metric-value" id="totalCostBasis">$96,780.14</span>
+                <span class="metric-delta" id="totalCostBasisNote">Across 28 positions</span>
+            </article>
+            <article class="metric-card">
+                <span class="metric-label">Total Gain / Loss</span>
+                <span class="metric-value positive" id="totalGainLoss">+$23,310.18</span>
+                <span class="metric-delta positive" id="totalGainLossPercent">+24.1%</span>
+            </article>
+        </section>
+
+        <section class="chart-card" aria-label="Account value chart">
+            <div class="chart-header">
+                <div>
+                    <h2>Account Value</h2>
+                    <p class="text-muted">Historical portfolio performance</p>
+                </div>
+                <div class="filters" role="group" aria-label="Time range filters">
+                    <button type="button" data-range="1M" class="active">1M</button>
+                    <button type="button" data-range="3M">3M</button>
+                    <button type="button" data-range="6M">6M</button>
+                    <button type="button" data-range="YTD">YTD</button>
+                    <div class="custom-range">
+                        <label for="startDate">Custom</label>
+                        <input type="date" id="startDate" aria-label="Start date">
+                        <span aria-hidden="true">–</span>
+                        <input type="date" id="endDate" aria-label="End date">
+                        <button type="button" id="applyCustom">Apply</button>
+                    </div>
+                </div>
+            </div>
+            <canvas id="valueChart" aria-label="Account value chart" role="img"></canvas>
+        </section>
+    </main>
+
+    <script>
+        window.addEventListener('DOMContentLoaded', () => {
+            const timestampEl = document.querySelector('.timestamp');
+            const updateTimestamp = () => {
+                const now = new Date();
+                const formatted = now.toLocaleString(undefined, {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                    hour: 'numeric',
+                    minute: '2-digit'
+                });
+                timestampEl.textContent = `Last updated ${formatted}`;
+            };
+            updateTimestamp();
+
+            const ctx = document.getElementById('valueChart');
+            const chartData = generateSampleData();
+            const chartInstance = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: chartData.labels,
+                    datasets: [{
+                        label: 'Account Value',
+                        data: chartData.values,
+                        fill: true,
+                        tension: 0.35,
+                        borderColor: 'rgba(108, 162, 255, 1)',
+                        backgroundColor: (ctx) => {
+                            const { ctx: canvasContext, chartArea } = ctx.chart;
+                            if (!chartArea) return 'rgba(108, 162, 255, 0.1)';
+                            const gradient = canvasContext.createLinearGradient(0, chartArea.bottom, 0, chartArea.top);
+                            gradient.addColorStop(0, 'rgba(76, 139, 245, 0.05)');
+                            gradient.addColorStop(1, 'rgba(108, 162, 255, 0.35)');
+                            return gradient;
+                        },
+                        pointRadius: 0,
+                        borderWidth: 2.4,
+                        fill: 'start',
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    scales: {
+                        x: {
+                            grid: {
+                                color: 'rgba(255, 255, 255, 0.04)'
+                            },
+                            ticks: {
+                                color: 'rgba(255, 255, 255, 0.55)'
+                            }
+                        },
+                        y: {
+                            grid: {
+                                color: 'rgba(255, 255, 255, 0.05)'
+                            },
+                            ticks: {
+                                color: 'rgba(255, 255, 255, 0.55)',
+                                callback: (value) => `$${value.toLocaleString()}`
+                            }
+                        }
+                    },
+                    plugins: {
+                        legend: {
+                            labels: {
+                                color: 'rgba(255, 255, 255, 0.65)'
+                            }
+                        },
+                        tooltip: {
+                            backgroundColor: 'rgba(12, 18, 29, 0.92)',
+                            titleColor: '#f4f7ff',
+                            bodyColor: '#cfd9f4',
+                            borderColor: 'rgba(76, 139, 245, 0.4)',
+                            borderWidth: 1,
+                            callbacks: {
+                                label: (context) => ` ${context.dataset.label}: $${context.parsed.y.toLocaleString()}`
+                            }
+                        }
+                    }
+                }
+            });
+
+            const filterButtons = document.querySelectorAll('.filters button[data-range]');
+            filterButtons.forEach(button => {
+                button.addEventListener('click', () => {
+                    filterButtons.forEach(btn => btn.classList.toggle('active', btn === button));
+                    const range = button.dataset.range;
+                    const { labels, values } = generateSampleData(range);
+                    chartInstance.data.labels = labels;
+                    chartInstance.data.datasets[0].data = values;
+                    chartInstance.update();
+                });
+            });
+
+            document.getElementById('applyCustom').addEventListener('click', () => {
+                const startDate = document.getElementById('startDate').value;
+                const endDate = document.getElementById('endDate').value;
+                if (!startDate || !endDate) {
+                    alert('Select both start and end dates to apply a custom range.');
+                    return;
+                }
+
+                const start = new Date(startDate);
+                const end = new Date(endDate);
+                if (start > end) {
+                    alert('Start date must be before the end date.');
+                    return;
+                }
+
+                filterButtons.forEach(btn => btn.classList.remove('active'));
+                const { labels, values } = generateSampleData('CUSTOM', start, end);
+                chartInstance.data.labels = labels;
+                chartInstance.data.datasets[0].data = values;
+                chartInstance.update();
+            });
+
+            function generateSampleData(range = '1M', startDate, endDate) {
+                const today = new Date();
+                let start;
+                switch (range) {
+                    case '1M':
+                        start = new Date(today);
+                        start.setMonth(start.getMonth() - 1);
+                        break;
+                    case '3M':
+                        start = new Date(today);
+                        start.setMonth(start.getMonth() - 3);
+                        break;
+                    case '6M':
+                        start = new Date(today);
+                        start.setMonth(start.getMonth() - 6);
+                        break;
+                    case 'YTD':
+                        start = new Date(today.getFullYear(), 0, 1);
+                        break;
+                    case 'CUSTOM':
+                        start = startDate || new Date(today);
+                        break;
+                    default:
+                        start = new Date(today);
+                }
+
+                const end = range === 'CUSTOM' ? (endDate || today) : today;
+                if (end < start) {
+                    return { labels: [], values: [] };
+                }
+
+                const labels = [];
+                const values = [];
+                const msPerDay = 1000 * 60 * 60 * 24;
+                const totalDays = Math.max(1, Math.round((end - start) / msPerDay));
+                let value = 120000;
+
+                for (let i = 0; i <= totalDays; i++) {
+                    const current = new Date(start);
+                    current.setDate(start.getDate() + i);
+                    labels.push(current.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }));
+                    const drift = Math.sin(i / 6) * 650;
+                    const noise = (Math.random() - 0.5) * 450;
+                    value = Math.max(80000, value + drift * 0.1 + noise * 0.15);
+                    values.push(Number(value.toFixed(2)));
+                }
+
+                return { labels, values };
+            }
+        });
+    </script>
+</body>
+</html>

--- a/Proof of Concept/portfolioLogin.html
+++ b/Proof of Concept/portfolioLogin.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Schwab Portfolio Login</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            color-scheme: dark;
+            --background: #0c0f17;
+            --surface: #141b29;
+            --surface-muted: #1e2738;
+            --accent: #4c8bf5;
+            --accent-strong: #6da2ff;
+            --text-primary: #f4f7ff;
+            --text-secondary: #a9b5d1;
+            --border: rgba(255, 255, 255, 0.08);
+            --danger: #ff6b6b;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: radial-gradient(circle at top, rgba(76, 139, 245, 0.22), transparent 55%),
+                        radial-gradient(circle at bottom, rgba(255, 255, 255, 0.03), transparent 40%),
+                        var(--background);
+            color: var(--text-primary);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+        }
+
+        main {
+            width: min(480px, 100%);
+        }
+
+        .card {
+            background: linear-gradient(145deg, rgba(30, 39, 56, 0.9), rgba(12, 15, 23, 0.95));
+            border: 1px solid var(--border);
+            border-radius: 18px;
+            padding: 36px;
+            backdrop-filter: blur(20px);
+            box-shadow:
+                0 20px 45px rgba(12, 15, 23, 0.75),
+                0 0 0 1px rgba(76, 139, 245, 0.04);
+        }
+
+        header {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            margin-bottom: 32px;
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 1.9rem;
+            letter-spacing: 0.04em;
+        }
+
+        header p {
+            margin: 0;
+            color: var(--text-secondary);
+            line-height: 1.6;
+        }
+
+        form {
+            display: grid;
+            gap: 20px;
+        }
+
+        label {
+            display: block;
+            font-size: 0.95rem;
+            font-weight: 500;
+            margin-bottom: 8px;
+        }
+
+        .input-group {
+            display: flex;
+            flex-direction: column;
+        }
+
+        input[type="text"],
+        input[type="password"] {
+            width: 100%;
+            padding: 14px 16px;
+            border-radius: 12px;
+            border: 1px solid var(--border);
+            background: var(--surface);
+            color: var(--text-primary);
+            font-size: 1rem;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+        }
+
+        input[type="text"]:focus,
+        input[type="password"]:focus {
+            outline: none;
+            border-color: rgba(76, 139, 245, 0.65);
+            box-shadow: 0 0 0 3px rgba(76, 139, 245, 0.25);
+            transform: translateY(-1px);
+        }
+
+        .options {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            flex-wrap: wrap;
+            font-size: 0.92rem;
+        }
+
+        .checkbox {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            cursor: pointer;
+            color: var(--text-secondary);
+        }
+
+        .checkbox input {
+            width: 18px;
+            height: 18px;
+            border-radius: 4px;
+            border: 1px solid var(--border);
+            appearance: none;
+            background: var(--surface);
+            display: grid;
+            place-items: center;
+            transition: border-color 0.2s ease, background 0.2s ease;
+        }
+
+        .checkbox input::after {
+            content: "";
+            width: 10px;
+            height: 10px;
+            border-radius: 2px;
+            transform: scale(0);
+            transition: transform 0.2s ease;
+            background: var(--accent);
+        }
+
+        .checkbox input:checked {
+            border-color: var(--accent);
+            background: rgba(76, 139, 245, 0.2);
+        }
+
+        .checkbox input:checked::after {
+            transform: scale(1);
+        }
+
+        .options a {
+            color: var(--accent-strong);
+            text-decoration: none;
+            font-weight: 500;
+            transition: color 0.2s ease;
+        }
+
+        .options a:hover,
+        .options a:focus {
+            color: #8bb6ff;
+        }
+
+        button {
+            border: none;
+            border-radius: 12px;
+            padding: 14px 18px;
+            font-size: 1rem;
+            font-weight: 600;
+            background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+            color: white;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        button:hover,
+        button:focus {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 25px rgba(76, 139, 245, 0.35);
+        }
+
+        .secondary-actions {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 24px;
+            gap: 12px;
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+        }
+
+        .secondary-actions a {
+            color: var(--accent-strong);
+            text-decoration: none;
+        }
+
+        .divider {
+            height: 1px;
+            background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+            margin: 12px 0;
+        }
+
+        footer {
+            margin-top: 40px;
+            text-align: center;
+            color: var(--text-secondary);
+            font-size: 0.85rem;
+            line-height: 1.6;
+        }
+
+        @media (max-width: 520px) {
+            .card {
+                padding: 28px 24px;
+            }
+
+            header h1 {
+                font-size: 1.6rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <section class="card" aria-labelledby="login-title">
+            <header>
+                <p style="font-size: 0.95rem; color: var(--accent-strong); letter-spacing: 0.18em; text-transform: uppercase;">
+                    Schwab Portfolio Tracker
+                </p>
+                <h1 id="login-title">Welcome back</h1>
+                <p>Access your personalized dashboard to monitor positions, performance, and daily insights from your Schwab portfolio.</p>
+            </header>
+
+            <form>
+                <div class="input-group">
+                    <label for="username">Username</label>
+                    <input type="text" id="username" name="username" autocomplete="username" placeholder="Enter Schwab ID" required />
+                </div>
+
+                <div class="input-group">
+                    <label for="password">Password</label>
+                    <input type="password" id="password" name="password" autocomplete="current-password" placeholder="Enter password" required />
+                </div>
+
+                <div class="options">
+                    <label class="checkbox">
+                        <input type="checkbox" id="remember" name="remember" />
+                        <span>Remember device</span>
+                    </label>
+                    <a href="#">Forgot password?</a>
+                </div>
+
+                <button type="submit">Log In</button>
+
+                <div class="secondary-actions">
+                    <span>Need an account?</span>
+                    <a href="#">Start tracking your portfolio</a>
+                </div>
+            </form>
+
+            <div class="divider" role="presentation"></div>
+
+            <footer>
+                <p>For demo purposes only. Connect your Schwab account in the live tracker to sync holdings automatically.</p>
+            </footer>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dark-themed Schwab portfolio overview dashboard to complement the existing login screen
- surface total account, cash, market value, day change, cost basis, and gain/loss metrics in glassmorphism cards
- integrate a Chart.js area chart with preset and custom date range filters for account value history

## Testing
- not run (static frontend page)


------
https://chatgpt.com/codex/tasks/task_e_68dbef1a22888325b87cd5e983380565